### PR TITLE
rich-itemsize-update: updated item size for responsive screen sizes

### DIFF
--- a/src/components/ImageGallery.js
+++ b/src/components/ImageGallery.js
@@ -130,11 +130,10 @@ const ImageGallery = ({
 
           <Grid
             templateColumns={{
-              base: "repeat(auto-fit, minmax(150px, 1fr))", // On smaller screens, minimum width is 150px
-              md: "repeat(auto-fit, minmax(200px, 1fr))", // Adjust as needed for different breakpoints
-              lg: "repeat(auto-fit, minmax(250px, 1fr))",
+              sm: "repeat(2, 1fr)",
+              md: "repeat(4, 1fr)",
+              lg: "repeat(6, 1fr)",
             }}
-            gridAutoRows="1fr"
             gap={4}
             p={5}
           >


### PR DESCRIPTION
updated item sizes upon searching, filtering, changing screen sizes.

<img width="1425" alt="Screenshot 2023-11-10 at 10 38 06 AM" src="https://github.com/Rich-Park/vandymarketplace/assets/84939700/d33cf591-c718-473a-8abe-fa3f2b73dc60">

<img width="1418" alt="Screenshot 2023-11-10 at 10 38 17 AM" src="https://github.com/Rich-Park/vandymarketplace/assets/84939700/59a3f716-8db5-4b2c-ae90-6265c7f7b6dc">
